### PR TITLE
Use pagination to get all library games

### DIFF
--- a/src/GameJoltLibrary/Models/LibraryGameInfo.cs
+++ b/src/GameJoltLibrary/Models/LibraryGameInfo.cs
@@ -13,6 +13,12 @@ internal class LibraryGamesResultPayload
 {
     [SerializationPropertyName("games")]
     public List<GameJoltGameMetadata> Games { get; set; }
+
+    [SerializationPropertyName("gamesCount")]
+    public int GamesCount { get; set; }
+
+    [SerializationPropertyName("perPage")]
+    public int PerPage { get; set; }
 }
 
 internal class LibraryGameResultPayload


### PR DESCRIPTION
The payload of the API request is paged, so a normal request only returns the first page, thus multiple requests (for each page we) have to be made.

fixes #16 